### PR TITLE
Add Support for winfdows Platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ CMakeLists.txt.user*
 .idea
 /cmake-build*
 .cache
+.vscode

--- a/cmake/FindDNSSD.cmake
+++ b/cmake/FindDNSSD.cmake
@@ -23,7 +23,7 @@ if (DNSSD_INCLUDE_DIR)
   if (APPLE)
     set(DNSSD_LIBRARIES "/usr/lib/libSystem.dylib")
   else (APPLE)
-    FIND_LIBRARY(DNSSD_LIBRARIES NAMES dns_sd )
+    FIND_LIBRARY(DNSSD_LIBRARIES NAMES dns_sd dnssd )
   endif (APPLE)
 
   cmake_push_check_state()

--- a/src/mdnsd-publicservice.cpp
+++ b/src/mdnsd-publicservice.cpp
@@ -12,7 +12,7 @@
 #include "servicebase_p.h"
 #include <QCoreApplication>
 #include <QStringList>
-#include <netinet/in.h>
+#include <QtEndian>
 
 #define KDNSSD_D PublicServicePrivate *d = static_cast<PublicServicePrivate *>(this->d.operator->())
 
@@ -168,7 +168,7 @@ void PublicService::publishAsync()
                            fullType.toLatin1().constData(),
                            domainToDNS(d->m_domain).constData(),
                            NULL,
-                           htons(d->m_port),
+                           qToBigEndian(d->m_port),
                            TXTRecordGetLength(&txt),
                            TXTRecordGetBytesPtr(&txt),
                            publish_callback,

--- a/src/mdnsd-remoteservice.cpp
+++ b/src/mdnsd-remoteservice.cpp
@@ -13,7 +13,7 @@
 #include <QCoreApplication>
 #include <QDebug>
 #include <QEventLoop>
-#include <netinet/in.h>
+#include <QtEndian>
 
 namespace KDNSSD
 {
@@ -148,7 +148,7 @@ void resolve_callback(DNSServiceRef,
             map[QString::fromUtf8(key)].clear();
         }
     }
-    ResolveEvent rev(DNSToDomain(hosttarget), ntohs(port), map);
+    ResolveEvent rev(DNSToDomain(hosttarget), qFromBigEndian(port), map);
     QCoreApplication::sendEvent(obj, &rev);
 }
 


### PR DESCRIPTION
Hope this library support Bonjour SDK so I modified the following things to make it work under Windows

1) When I Install Bonjour SDK for Windows it has the Following Tree

~~~
..
│
│
├───Include
│       dns_sd.h
│
│..
│
├───Lib
│   ├───Win32
│   │       dnssd.lib
│   │       dnssd.lib.pdb
│   │
│   └───x64
│           dnssd.lib
│           dnssd.lib.pdb
..
..
..
~~~

So I have added path `dnssd`.

2) change platform-specific functions by using `<QtEndian>`

> Note I have not tried to build this version but I have done for the version `v5.108.0`